### PR TITLE
lint: remove warning

### DIFF
--- a/.github/workflows/my_release_action.yaml
+++ b/.github/workflows/my_release_action.yaml
@@ -20,7 +20,8 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish package
-        run: mvn --batch-mode -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} deploy -Pdeploy
+        run: mvn --batch-mode deploy -Pdeploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -133,9 +133,6 @@
                   </goals>
                </execution>
             </executions>
-            <configuration>
-               <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
          </plugin>
       </plugins>
    </build>


### PR DESCRIPTION
 Warning:  Parameter 'additionalparam' is unknown for plugin 'maven-javadoc-plugin:3.11.2:jar (attach-javadocs)'

Warning:   Parameter 'passphrase' (user property 'gpg.passphrase') is deprecated: Do not use this configuration, it may leak sensitive information. Rely on gpg-agent or env variables instead.
Warning:
Warning:  W A R N I N G
Warning:
Warning:  Do not store passphrase in any file (disk or SCM repository),
Warning:  instead rely on GnuPG agent or provide passphrase in
Warning:  MAVEN_GPG_PASSPHRASE environment variable for batch mode.
Warning:
Warning:  Sensitive content loaded from Mojo configuration
Warning: