### PR TITLE
fix: replace getFile() with getInputStream() for better resource hand…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ Add the following to your project:
 <dependency>
   <groupId>com.clever-cloud</groupId>
   <artifactId>testcontainers-warp10</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
 </dependency>
 ```
 
 ### build.gradle
 
 ```
-implementation 'com.clever-cloud:testcontainers-warp10:2.0.0'
+implementation 'com.clever-cloud:testcontainers-warp10:2.0.1'
 ```
 
 ### build.sbt
 
 ```scala
-libraryDependencies += "com.clever-cloud" % "testcontainers-warp10" % "2.0.0"
+libraryDependencies += "com.clever-cloud" % "testcontainers-warp10" % "2.0.1"
 ```
 
 ## Usage example

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
    <url>https://github.com/CleverCloud/testcontainers-warp10</url>
    <groupId>com.clever-cloud</groupId>
    <artifactId>testcontainers-warp10</artifactId>
-   <version>2.0.0</version>
+   <version>2.0.1</version>
 
    <properties>
       <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/com/clevercloud/testcontainers/warp10/Warp10Container.java
+++ b/src/main/java/com/clevercloud/testcontainers/warp10/Warp10Container.java
@@ -126,17 +126,18 @@ public class Warp10Container extends GenericContainer<Warp10Container> {
     }
 
     private void uploadTokenGen() throws IOException {
-        InputStream inputStream = Warp10Container.class.getClassLoader().getResourceAsStream("tokengen.mc2");
-        if (inputStream == null) {
-            throw new FileNotFoundException("Resource tokengen.mc2 not found");
+        try (InputStream inputStream = Warp10Container.class.getClassLoader().getResourceAsStream("tokengen.mc2")) {
+            if (inputStream == null) {
+                throw new FileNotFoundException("Resource tokengen.mc2 not found");
+            }
+
+            Path tempPath = Files.createTempFile("tokengen", ".mc2");
+            Files.copy(inputStream, tempPath, StandardCopyOption.REPLACE_EXISTING);
+            tempPath.toFile().deleteOnExit();
+
+            MountableFile mountableFile = MountableFile.forHostPath(tempPath.toAbsolutePath());
+            copyFileToContainer(mountableFile, "/opt/warp10/tokens/tokengen.mc2");
         }
-
-        Path tempPath = Files.createTempFile("tokengen", ".mc2");
-        Files.copy(inputStream, tempPath, StandardCopyOption.REPLACE_EXISTING);
-        tempPath.toFile().deleteOnExit();
-
-        MountableFile mountableFile = MountableFile.forHostPath(tempPath.toAbsolutePath());
-        copyFileToContainer(mountableFile, "/opt/warp10/tokens/tokengen.mc2");
     }
 
 

--- a/src/main/java/com/clevercloud/testcontainers/warp10/Warp10Container.java
+++ b/src/main/java/com/clevercloud/testcontainers/warp10/Warp10Container.java
@@ -10,7 +10,12 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -120,9 +125,17 @@ public class Warp10Container extends GenericContainer<Warp10Container> {
         }
     }
 
-    private void uploadTokenGen() {
-        File tokenGenFile = new File(Objects.requireNonNull(Warp10Container.class.getClassLoader().getResource("tokengen.mc2")).getFile());
-        MountableFile mountableFile = MountableFile.forHostPath(tokenGenFile.getAbsolutePath());
+    private void uploadTokenGen() throws IOException {
+        InputStream inputStream = Warp10Container.class.getClassLoader().getResourceAsStream("tokengen.mc2");
+        if (inputStream == null) {
+            throw new FileNotFoundException("Resource tokengen.mc2 not found");
+        }
+
+        Path tempPath = Files.createTempFile("tokengen", ".mc2");
+        Files.copy(inputStream, tempPath, StandardCopyOption.REPLACE_EXISTING);
+        tempPath.toFile().deleteOnExit();
+
+        MountableFile mountableFile = MountableFile.forHostPath(tempPath.toAbsolutePath());
         copyFileToContainer(mountableFile, "/opt/warp10/tokens/tokengen.mc2");
     }
 


### PR DESCRIPTION
Updated resource access logic from resource.getFile() to resource.getInputStream() to ensure compatibility when running the application from an executable JAR.

Context:
- resource.getFile() relies on the resource being available as a physical file on the file system.
- This approach works in development environments like but fails when the application is packaged into a JAR, as resources inside JARs can't be accessed as regular files.

Solution:
- Switched to resource.getInputStream(), which provides a robust way to read the resource contents regardless of their location.

